### PR TITLE
Return RESULT_INVALID_SIG when appropriate

### DIFF
--- a/src/main/java/com/d2lvalence/idkeyauth/implementation/D2LUserContext.java
+++ b/src/main/java/com/d2lvalence/idkeyauth/implementation/D2LUserContext.java
@@ -187,7 +187,7 @@ public class D2LUserContext implements ID2LUserContext {
         } else if (resultCode == 403) {
             if (calculateServerSkewFromResponse(responseBody)) {
                 return D2LUserContext.RESULT_INVALID_TIMESTAMP;
-            } else if (responseBody.equals("Invalid Token")) {
+            } else if (responseBody.toLowerCase().equals("invalid token") || responseBody.toLowerCase().equals("token expired")) {
                 return D2LUserContext.RESULT_INVALID_SIG;
             } else {
                 return D2LUserContext.RESULT_NO_PERMISSION;


### PR DESCRIPTION
Fix method D2LUserContext.interpretResult to interpret HTTP 403 with either "invalid token" or "token expired" in the body as "RESULT_INVALID_SIG", regardless of case.